### PR TITLE
GLUE-264-토스트-컴포넌트-구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "next": "14.1.4",
     "react": "^18",
     "react-dom": "^18",
+    "react-hot-toast": "^2.4.1",
     "react-konva": "^18.2.10",
     "recoil": "^0.7.7",
     "tailwind-merge": "^2.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ dependencies:
   react-dom:
     specifier: ^18
     version: 18.2.0(react@18.2.0)
+  react-hot-toast:
+    specifier: ^2.4.1
+    version: 2.4.1(csstype@3.1.3)(react-dom@18.2.0)(react@18.2.0)
   react-konva:
     specifier: ^18.2.10
     version: 18.2.10(konva@9.3.6)(react-dom@18.2.0)(react@18.2.0)
@@ -3119,6 +3122,14 @@ packages:
       slash: 3.0.0
     dev: true
 
+  /goober@2.1.14(csstype@3.1.3):
+    resolution: {integrity: sha512-4UpC0NdGyAFqLNPnhCT2iHpza2q+RAY3GV85a/mRPdzyPQMsj0KmMMuetdIkzWRbJ+Hgau1EZztq8ImmiMGhsg==}
+    peerDependencies:
+      csstype: ^3.0.10
+    dependencies:
+      csstype: 3.1.3
+    dev: false
+
   /gopd@1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
     dependencies:
@@ -4991,6 +5002,20 @@ packages:
       loose-envify: 1.4.0
       react: 18.2.0
       scheduler: 0.23.0
+    dev: false
+
+  /react-hot-toast@2.4.1(csstype@3.1.3)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-j8z+cQbWIM5LY37pR6uZR6D4LfseplqnuAO4co4u8917hBUvXlEqyP1ZzqVLcqoyUesZZv/ImreoCeHVDpE5pQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: '>=16'
+      react-dom: '>=16'
+    dependencies:
+      goober: 2.1.14(csstype@3.1.3)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    transitivePeerDependencies:
+      - csstype
     dev: false
 
   /react-icons@4.12.0(react@18.2.0):

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { ReactNode } from 'react';
+import { ToastProvider } from '@/components/Common';
 import { luckiestGuy, pretendard } from './fonts';
 import '../styles/globals.css';
 
@@ -16,7 +17,7 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body className={`${luckiestGuy.variable} ${pretendard.variable}`}>
-        {children}
+        <ToastProvider>{children}</ToastProvider>
       </body>
     </html>
   );

--- a/src/components/Common/Toast/ToastProvider.ts
+++ b/src/components/Common/Toast/ToastProvider.ts
@@ -1,0 +1,37 @@
+'use client';
+
+/* eslint-disable */
+
+import { generateContext } from '@/react-utils';
+import { Dispatch, SetStateAction } from 'react';
+import { ToastOptions, ValueOrFunction } from 'react-hot-toast';
+
+export type StrictToastRenderable = JSX.Element | string;
+
+export const [ToastProvider, useToastContext] = generateContext<{
+  toastId: string;
+  setToastId: Dispatch<SetStateAction<string>>;
+  handleLoading: (
+    toastComponent: StrictToastRenderable,
+    options?: ToastOptions,
+  ) => void;
+  handleError: (
+    toastComponent: StrictToastRenderable,
+    options?: ToastOptions,
+  ) => void;
+  handleSuccess: (
+    toastComponent: StrictToastRenderable,
+    options?: ToastOptions,
+  ) => void;
+  handlePromise: (
+    promise: Promise<any>,
+    toastComponent: {
+      loading: StrictToastRenderable;
+      success: ValueOrFunction<StrictToastRenderable, any>;
+      error: ValueOrFunction<StrictToastRenderable, any>;
+    },
+    options?: ToastOptions,
+  ) => void;
+}>({
+  name: 'toast-context',
+});

--- a/src/components/Common/Toast/index.tsx
+++ b/src/components/Common/Toast/index.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+/* eslint-disable */
+
+import { ReactNode, useCallback, useMemo, useState } from 'react';
+import toast, { ToastOptions, Toaster, ValueOrFunction } from 'react-hot-toast';
+import {
+  ToastProvider as ToastContainer,
+  StrictToastRenderable,
+} from './ToastProvider';
+
+export default function ToastProvider({ children }: { children: ReactNode }) {
+  const [toastId, setToastId] = useState<string>('');
+
+  const handleLoading = useCallback(
+    (
+      toastComponent: StrictToastRenderable,
+      options?: Omit<ToastOptions, 'duration'>,
+    ) => {
+      setToastId(
+        toast.loading(toastComponent, {
+          position: 'bottom-center',
+          ...options,
+        }),
+      );
+    },
+    [],
+  );
+
+  const handleError = useCallback(
+    (toastComponent: StrictToastRenderable, options?: ToastOptions) => {
+      toast.error(toastComponent, { position: 'bottom-center', ...options });
+    },
+    [],
+  );
+
+  const handleSuccess = useCallback(
+    (toastComponent: StrictToastRenderable, options?: ToastOptions) => {
+      toast.success(toastComponent, { position: 'bottom-center', ...options });
+    },
+    [],
+  );
+  const handlePromise = useCallback(
+    (
+      promise: Promise<any>,
+      toastComponent: {
+        loading: StrictToastRenderable;
+        success: ValueOrFunction<StrictToastRenderable, any>;
+        error: ValueOrFunction<StrictToastRenderable, any>;
+      },
+      options?: ToastOptions,
+    ) => {
+      toast.promise(promise, toastComponent, {
+        position: 'bottom-center',
+        ...options,
+      });
+    },
+    [],
+  );
+
+  const value = useMemo(
+    () => ({
+      toastId,
+      setToastId,
+      handleLoading,
+      handleError,
+      handleSuccess,
+      handlePromise,
+    }),
+    [
+      toastId,
+      setToastId,
+      handleLoading,
+      handleError,
+      handleSuccess,
+      handlePromise,
+    ],
+  );
+
+  return (
+    <ToastContainer {...value}>
+      {children}
+      <Toaster containerStyle={{ bottom: '40px' }} />
+    </ToastContainer>
+  );
+}

--- a/src/components/Common/index.tsx
+++ b/src/components/Common/index.tsx
@@ -7,3 +7,4 @@ export { default as Input } from './Input';
 export { default as Editor } from './Editor';
 export { default as Switch } from './Switch';
 export { default as Nav } from './Nav';
+export { default as ToastProvider } from './Toast';

--- a/src/react-utils/generateContext.tsx
+++ b/src/react-utils/generateContext.tsx
@@ -10,7 +10,7 @@ import {
 interface ContextOptions<ContextType> {
   name: string;
   errorMessage?: string;
-  defaultContextValue: ContextType;
+  defaultContextValue?: ContextType;
 }
 
 type ProviderProps<ContextValuesType> = ContextValuesType & {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,1 @@
+export * from './type';

--- a/src/types/type/index.ts
+++ b/src/types/type/index.ts
@@ -1,0 +1,1 @@
+export * from './react';

--- a/src/types/type/react.ts
+++ b/src/types/type/react.ts
@@ -1,0 +1,3 @@
+import { ReactNode } from 'react';
+
+export type StrictPropsWithChildren = { children: ReactNode };


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?

- #19 를 구현했습니다.

<br>

## 2. 어떤 위험이나 장애를 발견했나요?

<br>

## 3. 관련 스크린샷을 첨부해주세요.

https://github.com/DoTheZ-Team/glue-fe/assets/86355699/834f6321-348f-4808-9276-c134c601e569

<br>

## 4. 완료 사항

- [x] toast 사용을 위한 `react-hot-toast` 라이브러리 설치 (6214cfcbf5a449635954a9e2d95a08a4ed93f6db)
- [x] `generateContext`의 `defaultContextValue`가 optional할 수 있도록 변경 (547bfda51399cb7a5820236bcf9b039f2ca88a86)
- [x] 토스트 컴포넌트 구현 (66b20632031b38bb37f373f9a1f857b1b611e4e8)

<br>

## 5. 추가 사항

close #19 

<br>
