### PR TITLE
GLUE-349-매칭-api-연결

### DIFF
--- a/src/api/core.ts
+++ b/src/api/core.ts
@@ -19,7 +19,7 @@ const axiosInstance: AxiosInstance = axios.create({
 
 axiosInstance.interceptors.request.use(
   async (config: InternalAxiosRequestConfig) => {
-    const accessToken = Cookies.get(ACCESS_TOKEN)!;
+    const accessToken = Cookies.get(ACCESS_TOKEN) as string;
 
     if (!accessToken) {
       return config;

--- a/src/app/(publish)/(route)/edit/[postId]/page.tsx
+++ b/src/app/(publish)/(route)/edit/[postId]/page.tsx
@@ -4,7 +4,7 @@ import { usePostDetailContext } from '@/app/blog/[blogId]/post/[postId]/componen
 import PostEditor from '@/app/(publish)/components/PostEditor';
 
 export default function Page() {
-  const postDetail = usePostDetailContext()!;
+  const postDetail = usePostDetailContext();
 
   return <PostEditor {...postDetail} />;
 }

--- a/src/app/(publish)/api/queries.tsx
+++ b/src/app/(publish)/api/queries.tsx
@@ -7,7 +7,7 @@ import { postBlogPost, BlogPostRequest } from '.';
 export const usePost = (id: number) => {
   const { push } = useRouter();
   const { handleSuccess, handleError, handleLoading, toastId } =
-    useToastContext()!;
+    useToastContext();
 
   return useMutation({
     mutationKey: ['post', id],

--- a/src/app/(publish)/hooks/useWritePost.ts
+++ b/src/app/(publish)/hooks/useWritePost.ts
@@ -8,7 +8,7 @@ import { usePost } from '../api/queries';
 import { BlogPostRequest } from '../api';
 
 export default function useWritePost() {
-  const { handleError } = useToastContext()!;
+  const { handleError } = useToastContext();
   // TODO: blogId 사용
   const { mutate } = usePost(8);
 

--- a/src/app/blog/[blogId]/post/[postId]/components/CommentsWrapper/Comments/ChildComments/ChildCommentsFallback.tsx
+++ b/src/app/blog/[blogId]/post/[postId]/components/CommentsWrapper/Comments/ChildComments/ChildCommentsFallback.tsx
@@ -7,7 +7,7 @@ import { StrictPropsWithChildren } from '@/types';
 export default function ChildCommentsFallback({
   children,
 }: StrictPropsWithChildren) {
-  const { error, resetErrorBoundary } = useErrorBoundaryContext()!;
+  const { error, resetErrorBoundary } = useErrorBoundaryContext();
 
   if (error !== null) {
     return <Button onClick={() => resetErrorBoundary()}>다시 시도하기</Button>;

--- a/src/app/blog/[blogId]/post/[postId]/components/CommentsWrapper/Comments/CommentFallback.tsx
+++ b/src/app/blog/[blogId]/post/[postId]/components/CommentsWrapper/Comments/CommentFallback.tsx
@@ -7,7 +7,7 @@ import { StrictPropsWithChildren } from '@/types';
 export default function CommentsFallback({
   children,
 }: StrictPropsWithChildren) {
-  const { error, resetErrorBoundary } = useErrorBoundaryContext()!;
+  const { error, resetErrorBoundary } = useErrorBoundaryContext();
 
   if (error !== null) {
     return <Button onClick={() => resetErrorBoundary()}>다시 시도하기</Button>;

--- a/src/app/blog/[blogId]/post/[postId]/components/CommentsWrapper/api/quries.ts
+++ b/src/app/blog/[blogId]/post/[postId]/components/CommentsWrapper/api/quries.ts
@@ -3,7 +3,7 @@ import { useToastContext } from '@/components/Common/Toast/ToastProvider';
 import { getComments, postComment, postLike, getChildComments } from '.';
 
 export const usePostLike = () => {
-  const { handleSuccess } = useToastContext()!;
+  const { handleSuccess } = useToastContext();
 
   return useMutation({
     mutationKey: ['post-like'],
@@ -23,7 +23,7 @@ export const useComments = (postId: number, page: number) =>
   });
 
 export const usePostComment = (postId: number) => {
-  const { handleSuccess } = useToastContext()!;
+  const { handleSuccess } = useToastContext();
 
   return useMutation({
     mutationKey: ['post-comment', postId],

--- a/src/app/blog/[blogId]/post/[postId]/components/CommentsWrapper/hooks/index.ts
+++ b/src/app/blog/[blogId]/post/[postId]/components/CommentsWrapper/hooks/index.ts
@@ -10,7 +10,7 @@ export default function useLike(postId: number) {
   const [like, setLike] = useState<boolean>(false);
   const {
     postDetail: { likeCount },
-  } = usePostDetailContext()!;
+  } = usePostDetailContext();
   const { mutate: postLike } = usePostLike();
 
   const handleLike = useCallback(() => {

--- a/src/app/blog/[blogId]/post/[postId]/components/PostDetailFallback/index.tsx
+++ b/src/app/blog/[blogId]/post/[postId]/components/PostDetailFallback/index.tsx
@@ -7,7 +7,7 @@ import { StrictPropsWithChildren } from '@/types';
 export default function PostDetailFallback({
   children,
 }: StrictPropsWithChildren) {
-  const { error, resetErrorBoundary } = useErrorBoundaryContext()!;
+  const { error, resetErrorBoundary } = useErrorBoundaryContext();
 
   if (error !== null) {
     // TODO: 변경

--- a/src/app/blog/[blogId]/post/[postId]/components/PostDetailHeader/api/quries.ts
+++ b/src/app/blog/[blogId]/post/[postId]/components/PostDetailHeader/api/quries.ts
@@ -3,7 +3,7 @@ import { useToastContext } from '@/components/Common/Toast/ToastProvider';
 import { postFollow, deletePosting } from '.';
 
 export const usePostFollow = () => {
-  const { handleSuccess } = useToastContext()!;
+  const { handleSuccess } = useToastContext();
 
   return useMutation({
     mutationKey: ['post-follow'],
@@ -16,7 +16,7 @@ export const usePostFollow = () => {
 };
 
 export const useDeletePosting = () => {
-  const { handleSuccess } = useToastContext()!;
+  const { handleSuccess } = useToastContext();
 
   return useMutation({
     mutationKey: ['delete-posting'],

--- a/src/app/blog/[blogId]/post/[postId]/components/PostDetailHeader/index.tsx
+++ b/src/app/blog/[blogId]/post/[postId]/components/PostDetailHeader/index.tsx
@@ -13,7 +13,7 @@ export default function PostDetailHeader({ postId }: { postId: string }) {
   const {
     postDetail: { title, createdAt, memberId },
     loginMemberId,
-  } = usePostDetailContext()!;
+  } = usePostDetailContext();
   const { follow, handleFollow } = useFollow(Number(postId));
   const name = '김성민';
   const port = usePortal({ id: 'edit-container' });

--- a/src/app/blog/[blogId]/post/[postId]/page.tsx
+++ b/src/app/blog/[blogId]/post/[postId]/page.tsx
@@ -16,7 +16,7 @@ export default function Page({
 }: {
   params: { postId: string };
 }) {
-  const { postDetail } = usePostDetailContext()!;
+  const { postDetail } = usePostDetailContext();
 
   return (
     <>

--- a/src/app/match/components/RecommendationFallback/index.tsx
+++ b/src/app/match/components/RecommendationFallback/index.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { Button } from '@/components/Common';
+import { useErrorBoundaryContext } from '@/react-utils/ErrorboundaryContext';
+import { StrictPropsWithChildren } from '@/types';
+
+export default function RecommendationFallback({
+  children,
+}: StrictPropsWithChildren) {
+  const { error, resetErrorBoundary } = useErrorBoundaryContext();
+
+  if (error !== null) {
+    // TODO: 변경
+    return <Button onClick={() => resetErrorBoundary()}>다시 시도하기</Button>;
+  }
+  return children;
+}

--- a/src/app/match/components/RecommendationFetcher/RecommendationContext.tsx
+++ b/src/app/match/components/RecommendationFetcher/RecommendationContext.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import { generateContext } from '@/react-utils';
+import { RecommendationResponse } from './api';
+
+export const [RecommendationProvider, useRecommendationContext] =
+  generateContext<RecommendationResponse[]>({
+    name: 'matching-context',
+  });

--- a/src/app/match/components/RecommendationFetcher/RecommendationContext.tsx
+++ b/src/app/match/components/RecommendationFetcher/RecommendationContext.tsx
@@ -4,6 +4,6 @@ import { generateContext } from '@/react-utils';
 import { RecommendationResponse } from './api';
 
 export const [RecommendationProvider, useRecommendationContext] =
-  generateContext<RecommendationResponse[]>({
+  generateContext<{ recommendations: RecommendationResponse[] }>({
     name: 'matching-context',
   });

--- a/src/app/match/components/RecommendationFetcher/api.ts
+++ b/src/app/match/components/RecommendationFetcher/api.ts
@@ -1,0 +1,11 @@
+import { http } from '@/api';
+
+export interface RecommendationResponse {
+  id: number;
+  profile: string;
+  title: string;
+  description: string;
+}
+
+export const getRecommendation = () =>
+  http.get<RecommendationResponse[]>({ url: '/blogs/recommendations' });

--- a/src/app/match/components/RecommendationFetcher/api.ts
+++ b/src/app/match/components/RecommendationFetcher/api.ts
@@ -1,11 +1,13 @@
 import { http } from '@/api';
 
 export interface RecommendationResponse {
-  id: number;
+  blogId: number;
   profile: string;
   title: string;
   description: string;
 }
 
 export const getRecommendation = () =>
-  http.get<RecommendationResponse[]>({ url: '/blogs/recommendations' });
+  http.post<RecommendationResponse[]>({
+    url: '/blogs/recommendations',
+  });

--- a/src/app/match/components/RecommendationFetcher/index.tsx
+++ b/src/app/match/components/RecommendationFetcher/index.tsx
@@ -7,5 +7,9 @@ import { useRecommendation } from './quries';
 export default function MatchingFetcher({ children }: StrictPropsWithChildren) {
   const { data } = useRecommendation();
 
-  return <RecommendationProvider {...data}>{children}</RecommendationProvider>;
+  return (
+    <RecommendationProvider recommendations={data}>
+      {children}
+    </RecommendationProvider>
+  );
 }

--- a/src/app/match/components/RecommendationFetcher/index.tsx
+++ b/src/app/match/components/RecommendationFetcher/index.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import { StrictPropsWithChildren } from '@/types';
+import { RecommendationProvider } from './RecommendationContext';
+import { useRecommendation } from './quries';
+
+export default function MatchingFetcher({ children }: StrictPropsWithChildren) {
+  const { data } = useRecommendation();
+
+  return <RecommendationProvider {...data}>{children}</RecommendationProvider>;
+}

--- a/src/app/match/components/RecommendationFetcher/quries.ts
+++ b/src/app/match/components/RecommendationFetcher/quries.ts
@@ -1,0 +1,9 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { getRecommendation } from './api';
+
+export const useRecommendation = () =>
+  useSuspenseQuery({
+    queryKey: ['recommndation'],
+    queryFn: () => getRecommendation(),
+    select: ({ result }) => result,
+  });

--- a/src/app/match/layout.tsx
+++ b/src/app/match/layout.tsx
@@ -2,6 +2,9 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import { ReactNode } from 'react';
 import { Nav, NavigationIcons } from '@/components/Common';
+import { AsyncBoundaryWithQuery } from '@/react-utils';
+import MatchingFetcher from './components/RecommendationFetcher';
+import RecommendationFallback from './components/RecommendationFallback';
 
 export const metadata: Metadata = {
   title: '매치',
@@ -25,7 +28,11 @@ export default function MatchLayout({
         </div>
       </Nav>
 
-      {children}
+      <AsyncBoundaryWithQuery>
+        <RecommendationFallback>
+          <MatchingFetcher>{children}</MatchingFetcher>
+        </RecommendationFallback>
+      </AsyncBoundaryWithQuery>
     </main>
   );
 }

--- a/src/app/match/page.tsx
+++ b/src/app/match/page.tsx
@@ -3,40 +3,11 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import Card from '@/components/MatchCards/Card';
-
-// FIXME: 더미 데이터 삭제
-const dummyMatches = [
-  {
-    id: 0,
-    name: '블로거 이름',
-    description: '좋은 블로거 설명',
-    matchRate: 86,
-    imageSrc: '/images/1.png',
-  },
-  {
-    id: 1,
-    name: '블로거 이름',
-    description: '좋은 블로거 설명',
-    matchRate: 95,
-    imageSrc: '/images/1.png',
-  },
-  {
-    id: 2,
-    name: '블로거 이름',
-    description: '좋은 블로거 설명',
-    matchRate: 93,
-    imageSrc: '/images/1.png',
-  },
-  {
-    id: 3,
-    name: '블로거 이름',
-    description: '좋은 블로거 설명',
-    matchRate: 84,
-    imageSrc: '/images/1.png',
-  },
-] as const;
+import { useRecommendationContext } from './components/RecommendationFetcher/RecommendationContext';
 
 export default function Page() {
+  const { recommendations } = useRecommendationContext();
+
   return (
     <section className="w-full relative">
       <section className="absolute-center w-[550px] top-50 flex flex-col gap-20">
@@ -46,31 +17,25 @@ export default function Page() {
         </h1>
 
         <div className="w-full h-[550px] bg-[#FF5BB4] rounded-20 grid grid-cols-2 grid-rows-2 justify-items-center items-center px-70 py-20">
-          {dummyMatches.map(
-            ({ id, name, description, matchRate, imageSrc }) => (
-              <Link key={id} href={`/blog/${id}`}>
-                <Card width="w-190" height="h-247">
-                  <Card.Image>
-                    <Image
-                      src={imageSrc}
-                      fill
-                      objectFit="contain"
-                      alt={`${name} image`}
-                      className="rounded-12"
-                    />
-                  </Card.Image>
+          {recommendations.map(({ blogId, profile, title, description }) => (
+            <Link key={blogId} href={`/blog/${blogId}`}>
+              <Card width="w-190" height="h-247">
+                <Card.Image>
+                  <Image
+                    src={profile}
+                    fill
+                    objectFit="contain"
+                    alt={`${title} image`}
+                    className="rounded-12"
+                  />
+                </Card.Image>
 
-                  <Card.Title>{name}</Card.Title>
+                <Card.Title>{title}</Card.Title>
 
-                  <Card.Description>{description}</Card.Description>
-
-                  <Card.Footer className="text-[#FF5BB4]">
-                    {matchRate}%
-                  </Card.Footer>
-                </Card>
-              </Link>
-            ),
-          )}
+                <Card.Description>{description}</Card.Description>
+              </Card>
+            </Link>
+          ))}
         </div>
       </section>
     </section>

--- a/src/app/subscribe/components/Feed/FeedContent.tsx
+++ b/src/app/subscribe/components/Feed/FeedContent.tsx
@@ -11,7 +11,7 @@ export default function FeedContent({
   currentPage,
   onPageChange,
 }: FeedContentProps) {
-  const { blogPostPreviews, isFirst, isLast } = useFollowPostContext()!;
+  const { blogPostPreviews, isFirst, isLast } = useFollowPostContext();
 
   return (
     <div>

--- a/src/app/subscribe/components/Subscription/FollowListContent.tsx
+++ b/src/app/subscribe/components/Subscription/FollowListContent.tsx
@@ -13,7 +13,7 @@ export default function FollowListContent({
   currentPage,
   onPageChange,
 }: FollowListContentProps) {
-  const { blogItems, isFirst, isLast } = useFollowListContext()!;
+  const { blogItems, isFirst, isLast } = useFollowListContext();
 
   return (
     <div className="flex flex-col justify-center">

--- a/src/app/subscribe/components/Subscription/FollowerListContent.tsx
+++ b/src/app/subscribe/components/Subscription/FollowerListContent.tsx
@@ -14,7 +14,7 @@ export default function FollowerListContent({
   currentPage,
   onPageChange,
 }: FollowerListContentProps) {
-  const { blogItems, isFirst, isLast } = useFollowerListContext()!;
+  const { blogItems, isFirst, isLast } = useFollowerListContext();
 
   return (
     <div className="flex flex-col justify-center">

--- a/src/app/subscribe/components/SubscriptionFallback/index.tsx
+++ b/src/app/subscribe/components/SubscriptionFallback/index.tsx
@@ -7,7 +7,7 @@ import { StrictPropsWithChildren } from '@/types';
 export default function SubscriptionFallback({
   children,
 }: StrictPropsWithChildren) {
-  const { error, resetErrorBoundary } = useErrorBoundaryContext()!;
+  const { error, resetErrorBoundary } = useErrorBoundaryContext();
 
   if (error !== null) {
     // TODO: 변경

--- a/src/components/Common/Dropdown/index.tsx
+++ b/src/components/Common/Dropdown/index.tsx
@@ -30,7 +30,7 @@ function Trigger({
   Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'onClick'>) {
   const {
     context: { onOpenChange },
-  } = useDropdownContext()!;
+  } = useDropdownContext();
 
   return (
     <Button {...props} onClick={() => onOpenChange()}>
@@ -40,7 +40,7 @@ function Trigger({
 }
 
 function Menu({ children }: StrictPropsWithChildren) {
-  const { context, getMenuProps } = useDropdownContext()!;
+  const { context, getMenuProps } = useDropdownContext();
   const { isOpen } = context;
   const dropdownAnimations: AnimationProps = useMemo(
     () => ({
@@ -65,7 +65,7 @@ function Item({
   ...props
 }: StrictPropsWithChildren &
   Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'onChange'>) {
-  const { getItemButtonProps } = useDropdownContext()!;
+  const { getItemButtonProps } = useDropdownContext();
 
   return (
     <Button

--- a/src/components/Common/Pagination/index.tsx
+++ b/src/components/Common/Pagination/index.tsx
@@ -6,7 +6,7 @@ import { UsePaginationProp, usePagination } from './usePagination';
 import { PaginationProvider, usePaginationContext } from './PaginationContext';
 
 function PrevButton() {
-  const { prevButton, getPrevButtonProps } = usePaginationContext()!;
+  const { prevButton, getPrevButtonProps } = usePaginationContext();
 
   return (
     <Button {...getPrevButtonProps()}>
@@ -16,7 +16,7 @@ function PrevButton() {
 }
 
 function NextButton() {
-  const { nextButton, getNextButtonProps } = usePaginationContext()!;
+  const { nextButton, getNextButtonProps } = usePaginationContext();
 
   return (
     <Button {...getNextButtonProps()}>
@@ -26,7 +26,7 @@ function NextButton() {
 }
 
 function PaginationContent() {
-  const { displayedPages, getPageButtonProps } = usePaginationContext()!;
+  const { displayedPages, getPageButtonProps } = usePaginationContext();
   const pages = displayedPages.length > 0 ? displayedPages : [1];
 
   return (

--- a/src/react-utils/AsyncBoundary.tsx
+++ b/src/react-utils/AsyncBoundary.tsx
@@ -16,7 +16,7 @@ type AsyncBoundrayProps = StrictPropsWithChildren &
   ErrorBoundaryProps &
   SuspenseProps & {
     errorFallback?: ComponentProps<typeof ErrorBoundary>['renderFallback'];
-    pendingFallback: ComponentProps<typeof Suspense>['fallback'];
+    pendingFallback?: ComponentProps<typeof Suspense>['fallback'];
   };
 
 export const AsyncBoundary = forwardRef<

--- a/src/react-utils/generateContext.tsx
+++ b/src/react-utils/generateContext.tsx
@@ -23,7 +23,7 @@ export default function generateContext<ContextType>(
   const {
     name,
     errorMessage = `useContext: ${name}Context가 존재하지 않습니다. Provider를 설정해주세요.`,
-    defaultContextValue,
+    defaultContextValue = null,
   } = options;
   const Context = createContext<ContextType | null>(
     defaultContextValue ?? null,


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?

- #49 를 구현했습니다.

<br>

## 2. 어떤 위험이나 장애를 발견했나요?

<br>

## 3. 관련 스크린샷을 첨부해주세요.

<img width="1468" alt="image" src="https://github.com/DoTheZ-Team/glue-fe/assets/86355699/957ed79f-4e47-4e04-b3ec-1660094d59ae">

<br>

## 4. 완료 사항

- [x] [추천 블로그를 제공받는 api, query, fetcher 컴포넌트 구현](https://github.com/DoTheZ-Team/glue-fe/commit/cd848690c4fa01dda505ddeaf3ac069ebd372da4)
- [x] [generateContext의 반환값이 undefined가 되지 않도록 변경](https://github.com/DoTheZ-Team/glue-fe/commit/a86d72c917597ae97ec0ef116d451cec61d5ee5f)
- [x] [추천 페이지의 fallback 컴포넌트 구현](https://github.com/DoTheZ-Team/glue-fe/commit/8349e856c6e2a649d804e48e60607b02846743bb)
- [x] [매칭 페이지 구현](https://github.com/DoTheZ-Team/glue-fe/commit/4e945a6c1e89abe212ef06de42569d0e198e35cf)

<br>

## 5. 추가 사항

close #49 

<br>
