### PR TITLE
GLUE-300-로그인정보-전역관리

### DIFF
--- a/src/app/(auth)/auth/api/index.ts
+++ b/src/app/(auth)/auth/api/index.ts
@@ -3,6 +3,7 @@ import http from '@/api/core';
 export interface LoginResponse {
   accessToken: string;
   refreshToken: string;
+  blogId: number;
 }
 
 export const postLogin = ({ code }: { code: string }) =>

--- a/src/app/(auth)/auth/api/queries.ts
+++ b/src/app/(auth)/auth/api/queries.ts
@@ -2,7 +2,7 @@ import { getQueryClient } from '@/app/lib';
 import { useMutation } from '@tanstack/react-query';
 import { ACCESS_TOKEN } from '@/constants';
 import Cookies from 'js-cookie';
-import { useUserContext } from '@/components/UserContext';
+import { useUserContext } from '@/components/Common/UserContext';
 import { postLogin } from '.';
 
 export const usePostLogin = (code: string) => {

--- a/src/app/(auth)/auth/api/queries.ts
+++ b/src/app/(auth)/auth/api/queries.ts
@@ -2,7 +2,7 @@ import { getQueryClient } from '@/app/lib';
 import { useMutation } from '@tanstack/react-query';
 import { ACCESS_TOKEN } from '@/constants';
 import Cookies from 'js-cookie';
-import { useUserContext } from '@/components/Common/UserContext';
+import { useUserContext } from '@/components/Common';
 import { postLogin } from '.';
 
 export const usePostLogin = (code: string) => {

--- a/src/app/(auth)/auth/api/queries.ts
+++ b/src/app/(auth)/auth/api/queries.ts
@@ -2,15 +2,20 @@ import { getQueryClient } from '@/app/lib';
 import { useMutation } from '@tanstack/react-query';
 import { ACCESS_TOKEN } from '@/constants';
 import Cookies from 'js-cookie';
+import { useUserContext } from '@/components/UserContext';
 import { postLogin } from '.';
 
-export const usePostLogin = (code: string) =>
-  useMutation({
+export const usePostLogin = (code: string) => {
+  const { setLoginId } = useUserContext();
+
+  return useMutation({
     mutationKey: ['login'],
     mutationFn: () => postLogin({ code }),
 
-    onSuccess: ({ result: { accessToken } }) => {
+    onSuccess: ({ result: { accessToken, blogId } }) => {
       Cookies.set(ACCESS_TOKEN, accessToken);
+      setLoginId(blogId);
       getQueryClient().invalidateQueries({ queryKey: ['login'] });
     },
   });
+};

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { ReactNode, Suspense } from 'react';
 import { ToastProvider } from '@/components/Common';
 import { GlobalErrorBoundary } from '@/react-utils/ErrorBoundary';
+import { UserProviderWrapper } from '@/components/UserContext';
 import { luckiestGuy, pretendard } from './fonts';
 import '../styles/globals.css';
 import QueryProvider from './lib/QueryProvider';
@@ -22,7 +23,9 @@ export default function RootLayout({
         <GlobalErrorBoundary renderFallback={<div>에러가 발생했어요 !</div>}>
           <Suspense fallback={<div>로딩 중입니다...</div>}>
             <ToastProvider>
-              <QueryProvider>{children}</QueryProvider>
+              <QueryProvider>
+                <UserProviderWrapper>{children}</UserProviderWrapper>
+              </QueryProvider>
             </ToastProvider>
           </Suspense>
         </GlobalErrorBoundary>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,7 @@
 import type { Metadata } from 'next';
 import { ReactNode, Suspense } from 'react';
-import { ToastProvider } from '@/components/Common';
+import { ToastProvider, UserProviderWrapper } from '@/components/Common';
 import { GlobalErrorBoundary } from '@/react-utils/ErrorBoundary';
-import { UserProviderWrapper } from '@/components/Common/UserContext';
 import { luckiestGuy, pretendard } from './fonts';
 import '../styles/globals.css';
 import QueryProvider from './lib/QueryProvider';

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import { ReactNode, Suspense } from 'react';
 import { ToastProvider } from '@/components/Common';
 import { GlobalErrorBoundary } from '@/react-utils/ErrorBoundary';
-import { UserProviderWrapper } from '@/components/UserContext';
+import { UserProviderWrapper } from '@/components/Common/UserContext';
 import { luckiestGuy, pretendard } from './fonts';
 import '../styles/globals.css';
 import QueryProvider from './lib/QueryProvider';

--- a/src/components/Common/UserContext/UserProviderWrapper.tsx
+++ b/src/components/Common/UserContext/UserProviderWrapper.tsx
@@ -1,0 +1,20 @@
+import { useMemo, useState } from 'react';
+import { UserProvider } from '.';
+
+export default function UserProviderWrapper({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [loginId, setLoginId] = useState<number | null>(null);
+
+  const contextValue = useMemo(
+    () => ({
+      loginId,
+      setLoginId,
+    }),
+    [loginId, setLoginId],
+  );
+
+  return <UserProvider {...contextValue}>{children}</UserProvider>;
+}

--- a/src/components/Common/UserContext/UserProviderWrapper.tsx
+++ b/src/components/Common/UserContext/UserProviderWrapper.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useMemo, useState } from 'react';
 import { UserProvider } from '.';
 

--- a/src/components/Common/UserContext/index.tsx
+++ b/src/components/Common/UserContext/index.tsx
@@ -1,16 +1,18 @@
 'use client';
 
 import { generateContext } from '@/react-utils';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 interface UserContextProps {
   loginId: number | null;
   setLoginId: (id: number | null) => void;
 }
 
-const [UserProvider, useUserContext] = generateContext<UserContextProps>({
-  name: 'user-info',
-});
+export const [UserProvider, useUserContext] = generateContext<UserContextProps>(
+  {
+    name: 'user-info',
+  },
+);
 
 export function UserProviderWrapper({
   children,
@@ -19,12 +21,13 @@ export function UserProviderWrapper({
 }) {
   const [loginId, setLoginId] = useState<number | null>(null);
 
-  const contextValue = useMemo(() => ({
-    loginId,
-    setLoginId,
-  }), [loginId, setLoginId]);
+  const contextValue = useMemo(
+    () => ({
+      loginId,
+      setLoginId,
+    }),
+    [loginId, setLoginId],
+  );
 
   return <UserProvider {...contextValue}>{children}</UserProvider>;
 }
-
-export { useUserContext };

--- a/src/components/Common/UserContext/index.tsx
+++ b/src/components/Common/UserContext/index.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useMemo, useState } from 'react';
 import { generateContext } from '@/react-utils';
 
 interface UserContextProps {
@@ -13,21 +12,3 @@ export const [UserProvider, useUserContext] = generateContext<UserContextProps>(
     name: 'user-info',
   },
 );
-
-export function UserProviderWrapper({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
-  const [loginId, setLoginId] = useState<number | null>(null);
-
-  const contextValue = useMemo(
-    () => ({
-      loginId,
-      setLoginId,
-    }),
-    [loginId, setLoginId],
-  );
-
-  return <UserProvider {...contextValue}>{children}</UserProvider>;
-}

--- a/src/components/Common/UserContext/index.tsx
+++ b/src/components/Common/UserContext/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { generateContext } from '@/react-utils';
 import { useMemo, useState } from 'react';
+import { generateContext } from '@/react-utils';
 
 interface UserContextProps {
   loginId: number | null;

--- a/src/components/Common/index.tsx
+++ b/src/components/Common/index.tsx
@@ -12,3 +12,5 @@ export { default as TextArea } from './TextArea';
 export { default as Pagination } from './Pagination';
 export { default as Dropdown } from './Dropdown';
 export { default as FileEdit } from './FileEdit';
+export { default as UserProviderWrapper } from './UserContext/UserProviderWrapper';
+export { useUserContext } from './UserContext';

--- a/src/components/UserContext/index.tsx
+++ b/src/components/UserContext/index.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { generateContext } from '@/react-utils';
+import { useState } from 'react';
+
+interface BlogContextProps {
+  loginId: number | null;
+  setLoginId: (id: number | null) => void;
+}
+
+const [UserProvider, useUserContext] = generateContext<BlogContextProps>({
+  name: 'user-info',
+});
+
+export function UserProviderWrapper({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [loginId, setLoginId] = useState<number | null>(null);
+
+  const contextValue = {
+    loginId,
+    setLoginId,
+  };
+
+  return <UserProvider {...contextValue}>{children}</UserProvider>;
+}
+
+export { useUserContext };

--- a/src/components/UserContext/index.tsx
+++ b/src/components/UserContext/index.tsx
@@ -19,10 +19,10 @@ export function UserProviderWrapper({
 }) {
   const [loginId, setLoginId] = useState<number | null>(null);
 
-  const contextValue = {
+  const contextValue = useMemo(() => ({
     loginId,
     setLoginId,
-  };
+  }), [loginId, setLoginId]);
 
   return <UserProvider {...contextValue}>{children}</UserProvider>;
 }

--- a/src/components/UserContext/index.tsx
+++ b/src/components/UserContext/index.tsx
@@ -3,12 +3,12 @@
 import { generateContext } from '@/react-utils';
 import { useState } from 'react';
 
-interface BlogContextProps {
+interface UserContextProps {
   loginId: number | null;
   setLoginId: (id: number | null) => void;
 }
 
-const [UserProvider, useUserContext] = generateContext<BlogContextProps>({
+const [UserProvider, useUserContext] = generateContext<UserContextProps>({
   name: 'user-info',
 });
 


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?

<br> 로그인 후 블로그 라우팅을 위해 유저의 블로그id가 필요하여 변경된 DTO 반영 후,   `loginId` 를 전역으로 관리합니다. 

## 2. 어떤 위험이나 장애를 발견했나요?

<br> 

## 3. 관련 스크린샷을 첨부해주세요.

<br>

## 4. 완료 사항

<br> 

- [x] userContext, userProvider 구현
- [x] 변경된 DTO 반영

## 5. 추가 사항

<br>

- 랜딩페이지에서 로그인 or 블로그 페이지로 이동하는 로직이 필요합니다.
